### PR TITLE
Modernize before arrest netid

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 **Change Description:** {{ FILL THIS IN }}
 
-**Closes Jira(s)**: {{ FILL THIS IN }}
+**Closes Issue(s)**: {{ FILL THIS IN }}
 
 ## Pull Request checklist
 

--- a/.github/scripts/gcr-login.sh
+++ b/.github/scripts/gcr-login.sh
@@ -1,7 +1,0 @@
-# Logs in to gcr using the GCR_TOKEN environment variable, which
-# must be a base64-encoded secret json key, set from a github secret.
-
-set -e
-
-echo "${GCR_TOKEN}" | base64 -d |
-  docker login --username _json_key --password-stdin https://gcr.io

--- a/.github/workflows/pull-request.template.yml
+++ b/.github/workflows/pull-request.template.yml
@@ -54,8 +54,6 @@ jobs:
           pip install poetry
           poetry install
 
-      # TODO: this is *backwards* - rather than update/maintain UWIT-IAM/actions/configure-gcloud-docker@0.1 we are re-writing it
-      #       I do note that it appears keeping *many actions* in a single repo is an anti-pattern
       - name: Auth to Google Cloud
         # important! this 'auth' is referenced as `steps.auth` on the next job
         id: auth
@@ -70,8 +68,6 @@ jobs:
         # requires role: roles/iam.serviceAccountTokenCreator
         run: |-
           echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
-
-      # end TODO
 
       - run: |
           # this will tag the image with e.g., "pull-request-15"

--- a/.github/workflows/pull-request.template.yml
+++ b/.github/workflows/pull-request.template.yml
@@ -20,15 +20,12 @@ jobs:
     outputs:
       new-version: ${{ steps.update-version.outputs.new-version }}
     steps:
-      - name: Python Poetry Action
-        uses: abatilo/actions-poetry@v2.1.4
-
       - uses: uwit-iam/actions/require-semver-guidance-label@0.1
         id: guidance
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: uwit-iam/actions/update-pr-branch-version@0.1
+      - uses: uwit-iam/actions/update-pr-branch-version@main
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
           version-guidance: ${{ steps.guidance.outputs.guidance }}
@@ -44,28 +41,45 @@ jobs:
     runs-on: ubuntu-latest
     env:
       APP_VERSION: ${{ needs.update-pr-branch-version.outputs.new-version }}
-      pr_tag: pull-request-${{ github.event.pull_request.number }}
+      pr_tag: pull-request-${{ github.event.pull_request.number }}  # e.g., "pull-request-15"
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: abatilo/actions-poetry@v2.1.4
-      - run: |
-          sudo apt-get -y install jq
-          poetry install
+      - name: Set up environment
         id: configure
-        name: Set up environment
+        run: |
+          sudo apt-get -y install jq
+          pip install poetry
+          poetry install
 
-      - uses: UWIT-IAM/actions/configure-gcloud-docker@0.1
+      # TODO: this is *backwards* - rather than update/maintain UWIT-IAM/actions/configure-gcloud-docker@0.1 we are re-writing it
+      #       I do note that it appears keeping *many actions* in a single repo is an anti-pattern
+      - name: Auth to Google Cloud
+        # important! this 'auth' is referenced as `steps.auth` on the next job
+        id: auth
+        # https://github.com/google-github-actions/auth#authenticating-via-service-account-key-json-1
+        uses: 'google-github-actions/auth@v1'
         with:
-          gcloud-token: ${{ secrets.GCR_TOKEN }}
+          credentials_json: '${{ secrets.MCI_GCLOUD_AUTH_JSON }}'
+          token_format: 'access_token'
+
+      - name: Auth to Google Artifact Registry
+        # https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
+        # requires role: roles/iam.serviceAccountTokenCreator
+        run: |-
+          echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
+
+      # end TODO
 
       - run: |
-          ./scripts/build.sh \
-            -t pull-request-${{ env.PR_TAG }} --cache
+          # this will tag the image with e.g., "pull-request-15"
+          # NOTE that this produces tags for ${template:app_name}.dependencies, ${template:app_name}.app, ${template:app_name}.tests (but not "${template:app_name}")
+          ./scripts/build.sh -t "${{ env.pr_tag }}" --cache
 
-      - run: docker push gcr.io/uwit-mci-iam/${template:app_name}:${{ env.pr_tag }}
+      # TODO: this container image URI should be dynamically generated from e..g, fingerprints.yaml
+      - run: docker push us-docker.pkg.dev/uwit-mci-iam/containers/${template:app_name}.app:${{ env.pr_tag }}
 
       - name: Run validation checks and tests
         run: |
@@ -76,7 +90,8 @@ jobs:
 
       - uses: mshick/add-pr-comment@v1
         env:
-          image: gcr.io/uwit-mci-iam/${template:app_name}:${{ env.pr_tag }}
+          # TODO: this container image URI should be dynamically generated from e..g, fingerprints.yaml
+          image: us-docker.pkg.dev/uwit-mci-iam/containers/${template:app_name}.app:${{ env.pr_tag }}
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           repo-token-user-login: 'github-actions[bot]'

--- a/.github/workflows/release-on-push-to-main.yaml
+++ b/.github/workflows/release-on-push-to-main.yaml
@@ -5,67 +5,62 @@ on:
       - main
     paths:
       - pyproject.toml
+  workflow_dispatch:
+
 jobs:
-  check-publishability:
+  publish-if-new-version:
     if: github.repository != 'UWIT-IAM/example-flask-app'
     runs-on: ubuntu-latest
-    outputs:
-      publishable: ${{ steps.check.outputs.publish }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-          # note: this may not longer be necessary but the below job was failing April 2023
-          # and using an explicit token fixed that
-          token: ${{ secrets.ACTIONS_PAT }}
+
       # Only publish if the version has changed; otherwise, we would be
       # re-publishing existing stuff without updating the version, and that
       # could cause problems.
-      - run: |
+      - name: Check if the change should be published
+        run: |
           set -x
           publishable=false
           diff=$(git diff HEAD:pyproject.toml HEAD~1:pyproject.toml) || exit 0
           echo "$diff" | grep '+version ='
-          if [[ "$?" == "0" ]]
+          if [[ "$?" -ne 0 ]]
           then
-            publishable=true
+            echo 'Not publishable - skipping'
+            exit 1
           fi
-          echo "::set-output name=publish::${publishable}"
-        name: Check if the change should be published
-        id: check
-  build-and-publish:
-    needs: [check-publishability]
-    if: needs.check-publishability.outputs.publishable == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
         with:
-          token: ${{ secrets.ACTIONS_PAT }}
+          python-version-file: pyproject.toml
 
       - name: Install and configure poetry
         run: |
           pipx install poetry
           poetry config virtualenvs.create false
 
-      - name: Install app
+      - name: Install package
         run: poetry install
 
-      - run: sudo apt-get -y install jq
+      - name: Install jq for fingerprinter
+        run: sudo apt-get -y install jq
 
-      - name: Log in to the Google container registry
-        run: ./.github/scripts/gcr-login.sh
-        env:
-          # UPDATE: If this repository is not in the UWIT-IAM
-          # org, you must ensure this secret exists, or update this
-          # value to use a secret that does exist. The token
-          # should be base64 encoded, and needs to be created by an
-          # Aux project administrator.
-          #
-          # If you are running inside the UWIT-IAM namespace,
-          # this is available for all repositories to use.
-          GITHUB_TOKEN: ${{ secrets.GCR_TOKEN }}
+      - name: Auth to Google Cloud
+        # important! this 'auth' is referenced as `steps.auth` on the next job
+        id: auth
+        # https://github.com/google-github-actions/auth#authenticating-via-service-account-key-json-1
+        uses: 'google-github-actions/auth@v1'
+        with:
+          credentials_json: '${{ secrets.MCI_GCLOUD_AUTH_JSON }}'
+          token_format: 'access_token'
+
+      - name: Auth to Google Artifact Registry
+        # https://github.com/google-github-actions/auth#authenticating-to-container-registry-and-artifact-registry
+        # requires role: roles/iam.serviceAccountTokenCreator
+        run: |-
+          echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://us-docker.pkg.dev
       - name: Create and push release image; deploy to dev
         run: |
+          # requires role: roles/artifactregistry.createOnPushWriter
           ./scripts/build.sh --release $(poetry version -s) --cache --deploy dev


### PR DESCRIPTION
This updates the bundled workflows to use GAR instead of GCR and refer to GH "Issues" instead of Jira.

Some documentation has been added to the publish workflow.